### PR TITLE
fix: correct image paths in EN tfs-command-line-destroying-items post

### DIFF
--- a/_posts/2013-05-05-tfs-command-line-destroying-items.md
+++ b/_posts/2013-05-05-tfs-command-line-destroying-items.md
@@ -13,11 +13,11 @@ This week I needed to remove a specific file from my TFS repository. Unfortunate
 
 Below is an image showing the execution of the `tf destroy` command:
 
-![Running tf destroy](/assets/images/tfs-command-line-destruindo-elementos/destroy.png)
+![Running tf destroy](/assets/images/tfs-command-line-destroying-items/destroy.png)
 
 And here is a brief explanation of each parameter:
 
-![tf destroy parameters](/assets/images/tfs-command-line-destruindo-elementos/info.png)
+![tf destroy parameters](/assets/images/tfs-command-line-destroying-items/info.png)
 
 That's basically it — hope it was helpful!
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,6 @@
   "packages": {
     "": {
       "name": "azborgonovo-tests",
-      "dependencies": {
-        "playwright": "^1.56.1"
-      },
       "devDependencies": {
         "@playwright/test": "^1.56.1"
       }
@@ -32,6 +29,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -46,6 +44,7 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.56.1"
@@ -64,6 +63,7 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
       "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"


### PR DESCRIPTION
The English post was referencing the Portuguese image folder name
(tfs-command-line-destruindo-elementos) instead of the shared slug
(tfs-command-line-destroying-items), causing broken images.

https://claude.ai/code/session_01LayYHoKXZgPRen4jdvzQgX