### PR TITLE
Add blog posts on Impact Networks, modular design, and team topologies

### DIFF
--- a/_posts/2021-12-08-beyond-coding-modular-software-pt-br.md
+++ b/_posts/2021-12-08-beyond-coding-modular-software-pt-br.md
@@ -1,0 +1,15 @@
+---
+lang: pt-br
+layout: post
+title: "Beyond Coding: Desenvolvimento de Software Modular"
+date: 2021-12-08
+categories: [coding]
+tags: [podcast, modular, design-de-software, midia]
+permalink: /coding/2021/12/08/beyond-coding-modular-software/
+---
+
+Design de software modular é um daqueles temas que parece simples na teoria, mas se torna surpreendentemente complexo na prática. Como definir fronteiras de módulo que façam sentido? Como evitar que o acoplamento forte volte a se instalar com o tempo? E como a forma de estruturar o código se conecta à forma de estruturar os times?
+
+Tive a oportunidade de explorar essas perguntas com Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding). Conversamos sobre os princípios do desenvolvimento modular, por que ele importa para a manutenibilidade a longo prazo, e alguns dos desafios reais que times de engenharia enfrentam ao tentar aplicá-lo.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/k1GUUublWxc" title="Beyond Coding: Desenvolvimento de Software Modular com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2021-12-08-beyond-coding-modular-software-pt-br.md
+++ b/_posts/2021-12-08-beyond-coding-modular-software-pt-br.md
@@ -8,7 +8,7 @@ tags: [podcast, modular, design-de-software, midia]
 permalink: /coding/2021/12/08/beyond-coding-modular-software/
 ---
 
-Design de software modular é um daqueles temas que parece simples na teoria, mas se torna surpreendentemente complexo na prática. Como definir fronteiras de módulo que façam sentido? Como evitar que o acoplamento forte volte a se instalar com o tempo? E como a forma de estruturar o código se conecta à forma de estruturar os times?
+Design de software modular é um daqueles temas que parece simples na teoria, mas se torna surpreendentemente complexo na prática. Como definir interfaces de módulo que façam sentido? Como evitar que o acoplamento forte volte a se instalar com o tempo? E como a forma de estruturar o código se conecta à forma de estruturar os times?
 
 Tive a oportunidade de explorar essas perguntas com Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding). Conversamos sobre os princípios do desenvolvimento modular, por que ele importa para a manutenibilidade a longo prazo, e alguns dos desafios reais que times de engenharia enfrentam ao tentar aplicá-lo.
 

--- a/_posts/2021-12-08-beyond-coding-modular-software-pt-br.md
+++ b/_posts/2021-12-08-beyond-coding-modular-software-pt-br.md
@@ -12,4 +12,4 @@ Design de software modular é um daqueles temas que parece simples na teoria, ma
 
 Tive a oportunidade de explorar essas perguntas com Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding). Conversamos sobre os princípios do desenvolvimento modular, por que ele importa para a manutenibilidade a longo prazo, e alguns dos desafios reais que times de engenharia enfrentam ao tentar aplicá-lo.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/k1GUUublWxc" title="Beyond Coding: Desenvolvimento de Software Modular com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/k1GUUublWxc" title="Beyond Coding: Desenvolvimento de Software Modular com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2021-12-08-beyond-coding-modular-software.md
+++ b/_posts/2021-12-08-beyond-coding-modular-software.md
@@ -7,7 +7,7 @@ categories: [coding]
 tags: [podcast, modular, software-design, midia]
 ---
 
-Modular software design is one of those topics that sounds straightforward in theory but gets surprisingly complex in practice. How do you define meaningful module boundaries? How do you prevent tight coupling from creeping back in over time? And how does the way you structure your code connect to the way you structure your teams?
+Modular software design is one of those topics that sounds straightforward in theory but gets surprisingly complex in practice. How do you define meaningful module interfaces? How do you prevent tight coupling from creeping back in over time? And how does the way you structure your code connect to the way you structure your teams?
 
 I had the chance to explore these questions with Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast. We talked about the principles behind modular development, why it matters for long-term maintainability, and some of the real challenges engineering teams face when trying to apply it.
 

--- a/_posts/2021-12-08-beyond-coding-modular-software.md
+++ b/_posts/2021-12-08-beyond-coding-modular-software.md
@@ -1,0 +1,14 @@
+---
+lang: en
+layout: post
+title: "Beyond Coding: Modular Software Development"
+date: 2021-12-08
+categories: [coding]
+tags: [podcast, modular, software-design, midia]
+---
+
+Modular software design is one of those topics that sounds straightforward in theory but gets surprisingly complex in practice. How do you define meaningful module boundaries? How do you prevent tight coupling from creeping back in over time? And how does the way you structure your code connect to the way you structure your teams?
+
+I had the chance to explore these questions with Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast. We talked about the principles behind modular development, why it matters for long-term maintainability, and some of the real challenges engineering teams face when trying to apply it.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/k1GUUublWxc" title="Beyond Coding: Modular Software Development with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2021-12-08-beyond-coding-modular-software.md
+++ b/_posts/2021-12-08-beyond-coding-modular-software.md
@@ -11,4 +11,4 @@ Modular software design is one of those topics that sounds straightforward in th
 
 I had the chance to explore these questions with Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast. We talked about the principles behind modular development, why it matters for long-term maintainability, and some of the real challenges engineering teams face when trying to apply it.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/k1GUUublWxc" title="Beyond Coding: Modular Software Development with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/k1GUUublWxc" title="Beyond Coding: Modular Software Development with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2024-10-16-leap-into-tech-diversity-pt-br.md
+++ b/_posts/2024-10-16-leap-into-tech-diversity-pt-br.md
@@ -4,7 +4,7 @@ layout: post
 title: "Leap into Tech: Diversidade no Mercado de Tecnologia"
 date: 2024-10-16
 categories: [people]
-tags: [podcast, diversidade, inclusão, mercado-de-tech, midia]
+tags: [podcast, diversidade, inclusão, mercado, midia]
 permalink: /people/2024/10/16/leap-into-tech-diversity/
 ---
 

--- a/_posts/2024-10-16-leap-into-tech-diversity-pt-br.md
+++ b/_posts/2024-10-16-leap-into-tech-diversity-pt-br.md
@@ -1,0 +1,15 @@
+---
+lang: pt-br
+layout: post
+title: "Leap into Tech: Diversidade no Mercado de Tecnologia"
+date: 2024-10-16
+categories: [people]
+tags: [podcast, diversidade, inclusão, mercado-de-tech, midia]
+permalink: /people/2024/10/16/leap-into-tech-diversity/
+---
+
+Construir uma indústria de tecnologia verdadeiramente diversa e inclusiva vai muito além de cotas de contratação ou iniciativas pontuais. Requer examinar as barreiras sistêmicas que impedem as pessoas de entrar na área, avançar nela e se sentir pertencentes. É um desafio que toca recrutamento, cultura, liderança e até a forma como desenhamos produtos.
+
+Me juntei a Ben Quinn, Mark Scheepens e Kim van Wilgen para uma mesa-redonda no podcast [Leap into Tech](https://open.spotify.com/episode/02DUAajVD395X0lh91tgPf) para falar sobre diversidade no mercado de tecnologia — compartilhando diferentes perspectivas sobre o que está travando o progresso e como é uma mudança real na prática.
+
+<iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/02DUAajVD395X0lh91tgPf" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>

--- a/_posts/2024-10-16-leap-into-tech-diversity.md
+++ b/_posts/2024-10-16-leap-into-tech-diversity.md
@@ -1,0 +1,14 @@
+---
+lang: en
+layout: post
+title: "Leap into Tech: Diversity in the Tech Market"
+date: 2024-10-16
+categories: [people]
+tags: [podcast, diversity, inclusion, tech-market, midia]
+---
+
+Building a truly diverse and inclusive tech industry is about more than hiring quotas or one-off initiatives. It requires examining the systemic barriers that prevent people from entering the field, advancing within it, and feeling like they belong. It's a challenge that touches recruitment, culture, leadership, and even how we design products.
+
+I joined Ben Quinn, Mark Scheepens, and Kim van Wilgen for a roundtable discussion on the [Leap into Tech](https://open.spotify.com/episode/02DUAajVD395X0lh91tgPf) podcast to talk about diversity in the tech market — sharing our different perspectives on what's holding progress back and what real change looks like in practice.
+
+<iframe style="border-radius:12px" src="https://open.spotify.com/embed/episode/02DUAajVD395X0lh91tgPf" width="100%" height="152" frameborder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
@@ -1,15 +1,15 @@
 ---
 lang: pt-br
 layout: post
-title: "Beyond Coding: Como Times e Arquitetura se Influenciam Mutuamente"
+title: "Por que o seu diagrama organizacional está quebrando seu software"
 date: 2025-03-16
 categories: [people]
 tags: [podcast, team-topologies, arquitetura, lei-de-conway, midia]
 permalink: /people/2025/03/16/beyond-coding-team-topologies/
 ---
 
-A Lei de Conway afirma que as organizações criam sistemas que espelham sua própria estrutura de comunicação. Mas a relação entre times e arquitetura não é unidirecional — a forma como você molda sua arquitetura também retroalimenta a maneira como seus times colaboram e evoluem. Essa interação está no centro do Team Topologies, framework de Matthew Skelton e Manuel Pais que transformou a visão de muitas organizações de engenharia sobre design de times.
+A Lei de Conway afirma que as organizações criam sistemas que espelham sua própria estrutura de comunicação. Mas a relação entre times e arquitetura não é unidirecional — a forma como você molda sua arquitetura também retroalimenta a maneira como seus times colaboram e evoluem. Essa interação está no centro de [Team Topologies](https://teamtopologies.com/), framework de Matthew Skelton e Manuel Pais que transformou a visão de muitas organizações de engenharia sobre design de times.
 
-Me juntei a Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding) para uma conversa sobre exatamente isso: como a reestruturação de times afeta o software que eles constroem, as armadilhas de fazer isso errado, e lições práticas de quem vivenciou essas mudanças como gestor de engenharia.
+Em uma conversa com Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding) falamos sobre como a reestruturação de times afeta o software que eles constroem, os riscos de fazer isso errado, e minhas lições enquanto Gerente de Engenharia.
 
 <iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: Como Times e Arquitetura se Influenciam Mutuamente com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
@@ -1,7 +1,7 @@
 ---
 lang: pt-br
 layout: post
-title: "Por que o seu diagrama organizacional está quebrando seu software"
+title: "Por que o seu diagrama organizacional pode estar quebrando seu software"
 date: 2025-03-16
 categories: [people]
 tags: [podcast, team-topologies, arquitetura, lei-de-conway, midia]
@@ -12,4 +12,4 @@ A Lei de Conway afirma que as organizações criam sistemas que espelham sua pr�
 
 Em uma conversa com Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding) falamos sobre como a reestruturação de times afeta o software que eles constroem, os riscos de fazer isso errado, e minhas lições enquanto Gerente de Engenharia.
 
-<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: Como Times e Arquitetura se Influenciam Mutuamente com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Por que o seu diagrama organizacional pode estar quebrando seu software com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
@@ -12,4 +12,4 @@ A Lei de Conway afirma que as organizações criam sistemas que espelham sua pr�
 
 Me juntei a Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding) para uma conversa sobre exatamente isso: como a reestruturação de times afeta o software que eles constroem, as armadilhas de fazer isso errado, e lições práticas de quem vivenciou essas mudanças como gestor de engenharia.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: Como Times e Arquitetura se Influenciam Mutuamente com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: Como Times e Arquitetura se Influenciam Mutuamente com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies-pt-br.md
@@ -1,0 +1,15 @@
+---
+lang: pt-br
+layout: post
+title: "Beyond Coding: Como Times e Arquitetura se Influenciam Mutuamente"
+date: 2025-03-16
+categories: [people]
+tags: [podcast, team-topologies, arquitetura, lei-de-conway, midia]
+permalink: /people/2025/03/16/beyond-coding-team-topologies/
+---
+
+A Lei de Conway afirma que as organizações criam sistemas que espelham sua própria estrutura de comunicação. Mas a relação entre times e arquitetura não é unidirecional — a forma como você molda sua arquitetura também retroalimenta a maneira como seus times colaboram e evoluem. Essa interação está no centro do Team Topologies, framework de Matthew Skelton e Manuel Pais que transformou a visão de muitas organizações de engenharia sobre design de times.
+
+Me juntei a Patrick Akil no podcast [Beyond Coding](https://www.youtube.com/@BeyondCoding) para uma conversa sobre exatamente isso: como a reestruturação de times afeta o software que eles constroem, as armadilhas de fazer isso errado, e lições práticas de quem vivenciou essas mudanças como gestor de engenharia.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: Como Times e Arquitetura se Influenciam Mutuamente com André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies.md
@@ -1,0 +1,14 @@
+---
+lang: en
+layout: post
+title: "Beyond Coding: How Teams and Architecture Influence Each Other"
+date: 2025-03-16
+categories: [people]
+tags: [podcast, team-topologies, architecture, conways-law, midia]
+---
+
+Conway's Law states that organisations design systems that mirror their own communication structure. But the relationship between teams and architecture is not one-directional — the way you shape your architecture also feeds back into how your teams collaborate and evolve. This interplay is at the heart of Team Topologies, a framework by Matthew Skelton and Manuel Pais that has reshaped how many engineering organisations think about team design.
+
+I joined Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast for a conversation about exactly this: how restructuring teams affects the software they build, the pitfalls of getting it wrong, and practical lessons from working through these changes as an engineering manager.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: How Teams and Architecture Influence Each Other with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies.md
@@ -11,4 +11,4 @@ Conway's Law states that organisations design systems that mirror their own comm
 
 I joined Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast for a conversation about how restructuring teams affects the software they build, the pitfalls of getting it wrong, and practical lessons from working through these changes as an Engineering Manager.
 
-<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: How Teams and Architecture Influence Each Other with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Why Your Org Chart is Breaking Your Software with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies.md
@@ -11,4 +11,4 @@ Conway's Law states that organisations design systems that mirror their own comm
 
 I joined Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast for a conversation about exactly this: how restructuring teams affects the software they build, the pitfalls of getting it wrong, and practical lessons from working through these changes as an engineering manager.
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: How Teams and Architecture Influence Each Other with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: How Teams and Architecture Influence Each Other with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-03-16-beyond-coding-team-topologies.md
+++ b/_posts/2025-03-16-beyond-coding-team-topologies.md
@@ -1,14 +1,14 @@
 ---
 lang: en
 layout: post
-title: "Beyond Coding: How Teams and Architecture Influence Each Other"
+title: "Why Your Org Chart is Breaking Your Software"
 date: 2025-03-16
 categories: [people]
 tags: [podcast, team-topologies, architecture, conways-law, midia]
 ---
 
-Conway's Law states that organisations design systems that mirror their own communication structure. But the relationship between teams and architecture is not one-directional — the way you shape your architecture also feeds back into how your teams collaborate and evolve. This interplay is at the heart of Team Topologies, a framework by Matthew Skelton and Manuel Pais that has reshaped how many engineering organisations think about team design.
+Conway's Law states that organisations design systems that mirror their own communication structure. But the relationship between teams and architecture is not one-directional — the way you shape your architecture also feeds back into how your teams collaborate and evolve. This interplay is at the heart of [Team Topologies](https://teamtopologies.com/), a framework by Matthew Skelton and Manuel Pais that has reshaped how many engineering organisations think about team design.
 
-I joined Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast for a conversation about exactly this: how restructuring teams affects the software they build, the pitfalls of getting it wrong, and practical lessons from working through these changes as an engineering manager.
+I joined Patrick Akil on the [Beyond Coding](https://www.youtube.com/@BeyondCoding) podcast for a conversation about how restructuring teams affects the software they build, the pitfalls of getting it wrong, and practical lessons from working through these changes as an Engineering Manager.
 
 <iframe style="display: block; margin: 0 auto; width: 80%; border-radius: 8px;" width="80%" height="380" src="https://www.youtube.com/embed/wi6-DnxAoQ0" title="Beyond Coding: How Teams and Architecture Influence Each Other with André Borgonovo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/_posts/2025-09-29-miro-impact-network-pt-br.md
+++ b/_posts/2025-09-29-miro-impact-network-pt-br.md
@@ -4,14 +4,16 @@ layout: post
 title: "Miroverse: Template de Impact Network (iNet)"
 date: 2025-09-29
 categories: [coding]
-tags: [miro, template, impact-network, visualização, midia]
+tags: [miro, template, impact-network, visualização, mídia]
 permalink: /coding/2025/09/29/miro-impact-network/
 ---
 
-Um Impact Network (iNet) é um diagrama de causa e efeito que mapeia como métricas, iniciativas e fatores se influenciam dentro de um sistema. O conceito vem do livro *Impact Intelligence* de Sriram Narayan — uma leitura que recomendo bastante para quem trabalha com estratégia de produto, eficácia de engenharia ou design de OKRs.
+Descobri *Impact Intelligence* através do artigo de Martin Fowler [The Reformist CTO's Guide to Impact Intelligence](https://martinfowler.com/articles/impact-intel.html). Sriram Narayan, o autor, escreveu um livro completo sobre o tema.
 
-O conceito é poderoso, mas desenhar um iNet do zero em uma tela em branco pode gerar mais atrito do que o necessário. Por isso criei um [template no Miroverse](https://miro.com/templates/impact-network-inet/) para dar às equipes um ponto de partida pronto: formas de nós pré-estilizadas, uma legenda e conexões de exemplo para estruturar o diagrama rapidamente.
+O livro *Impact Intelligence* explora como medir e amplificar o impacto de negócios dos esforços de tecnologia, usando frameworks práticos para conectar o trabalho técnico com resultados reais.
 
-Se você ainda não conhece os Impact Networks, o próprio template inclui um guia resumido da notação — você pode usar para aprender o conceito enquanto constrói seu primeiro diagrama.
+Uma ferramenta-chave do livro é o Impact Network (iNet), um diagrama de causa e efeito que mostra como métricas e iniciativas interagem dentro de um sistema. É uma ferramenta incrivelmente útil para estratégia de negócios e iniciativas tecnológicas.
 
-**[Abrir o template Impact Network (iNet) no Miroverse →](https://miro.com/templates/impact-network-inet/)**
+Criei um [template no Miroverse](https://miro.com/templates/impact-network-inet/) com elementos pré-estilizados, uma legenda e diagramas de exemplo para facilitar a criação de um iNet no Miro. Inclui um guia rápido da notação, então você pode aprender enquanto constrói seu primeiro diagrama.
+
+Confira: **[Template Impact Network (iNet) no Miroverse →](https://miro.com/templates/impact-network-inet/)**

--- a/_posts/2025-09-29-miro-impact-network-pt-br.md
+++ b/_posts/2025-09-29-miro-impact-network-pt-br.md
@@ -1,0 +1,17 @@
+---
+lang: pt-br
+layout: post
+title: "Miroverse: Template de Impact Network (iNet)"
+date: 2025-09-29
+categories: [coding]
+tags: [miro, template, impact-network, visualização, midia]
+permalink: /coding/2025/09/29/miro-impact-network/
+---
+
+Um Impact Network (iNet) é um diagrama de causa e efeito que mapeia como métricas, iniciativas e fatores se influenciam dentro de um sistema. O conceito vem do livro *Impact Intelligence* de Sriram Narayan — uma leitura que recomendo bastante para quem trabalha com estratégia de produto, eficácia de engenharia ou design de OKRs.
+
+O conceito é poderoso, mas desenhar um iNet do zero em uma tela em branco pode gerar mais atrito do que o necessário. Por isso criei um [template no Miroverse](https://miro.com/templates/impact-network-inet/) para dar às equipes um ponto de partida pronto: formas de nós pré-estilizadas, uma legenda e conexões de exemplo para estruturar o diagrama rapidamente.
+
+Se você ainda não conhece os Impact Networks, o próprio template inclui um guia resumido da notação — você pode usar para aprender o conceito enquanto constrói seu primeiro diagrama.
+
+**[Abrir o template Impact Network (iNet) no Miroverse →](https://miro.com/templates/impact-network-inet/)**

--- a/_posts/2025-09-29-miro-impact-network.md
+++ b/_posts/2025-09-29-miro-impact-network.md
@@ -4,13 +4,15 @@ layout: post
 title: "Miroverse: Impact Network (iNet) Template"
 date: 2025-09-29
 categories: [coding]
-tags: [miro, template, impact-network, visualisation, midia]
+tags: [miro, template, impact-network, visualisation, media]
 ---
 
-An Impact Network (iNet) is a cause-and-effect diagram that maps how metrics, initiatives, and factors influence each other within a system. It comes from *Impact Intelligence* by Sriram Narayan — a book I'd strongly recommend to anyone working on product strategy, engineering effectiveness, or OKR design.
+I first stumbled upon Impact Intelligence through Martin Fowler's article [The Reformist CTO's Guide to Impact Intelligence](https://martinfowler.com/articles/impact-intel.html). Sriram Narayan who is the author has written a full book about the topic.
 
-The concept is powerful, but sketching an iNet from scratch on a blank canvas is often more friction than it needs to be. So I built a [Miro template on Miroverse](https://miro.com/templates/impact-network-inet/) to give teams a ready-made starting point: pre-styled node shapes, a legend, and example connections to get the structure going quickly.
+The *Impact Intelligence* book dives into measuring and amplifying the business impact of software engineering efforts, using practical frameworks to connect technical work with real outcomes.
 
-If you're not familiar with Impact Networks yet, the template itself includes a brief guide to the notation — you can use it to learn the concept while building your first diagram.
+One key tool from the book is the Impact Network (iNet), a cause-and-effect diagram that depicts how metrics, initiatives, and factors interact within a system. It can be an incredibly useful tool for strategizing on business and tech initiatives.
 
-**[Open the Impact Network (iNet) template on Miroverse →](https://miro.com/templates/impact-network-inet/)**
+I created a [template on Miroverse](https://miro.com/templates/impact-network-inet/) with pre-styled nodes, a legend, and sample connections to make it easier to create an iNet in Miro. It includes a quick guide to the notation, so you can learn as you build.
+
+Check it out: **[Impact Network (iNet) template on Miroverse →](https://miro.com/templates/impact-network-inet/)**

--- a/_posts/2025-09-29-miro-impact-network.md
+++ b/_posts/2025-09-29-miro-impact-network.md
@@ -1,0 +1,16 @@
+---
+lang: en
+layout: post
+title: "Miroverse: Impact Network (iNet) Template"
+date: 2025-09-29
+categories: [coding]
+tags: [miro, template, impact-network, visualisation, midia]
+---
+
+An Impact Network (iNet) is a cause-and-effect diagram that maps how metrics, initiatives, and factors influence each other within a system. It comes from *Impact Intelligence* by Sriram Narayan — a book I'd strongly recommend to anyone working on product strategy, engineering effectiveness, or OKR design.
+
+The concept is powerful, but sketching an iNet from scratch on a blank canvas is often more friction than it needs to be. So I built a [Miro template on Miroverse](https://miro.com/templates/impact-network-inet/) to give teams a ready-made starting point: pre-styled node shapes, a legend, and example connections to get the structure going quickly.
+
+If you're not familiar with Impact Networks yet, the template itself includes a brief guide to the notation — you can use it to learn the concept while building your first diagram.
+
+**[Open the Impact Network (iNet) template on Miroverse →](https://miro.com/templates/impact-network-inet/)**

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,6 @@
   "packages": {
     "": {
       "name": "azborgonovo-tests",
-      "dependencies": {
-        "playwright": "^1.56.1"
-      },
       "devDependencies": {
         "@playwright/test": "^1.56.1"
       }
@@ -32,6 +29,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -46,6 +44,7 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.56.1"
@@ -64,6 +63,7 @@
       "version": "1.56.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
       "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"


### PR DESCRIPTION
## Summary
This PR adds six new blog posts covering technical and organizational topics, with bilingual support (English and Portuguese).

## Changes
- **Impact Network (iNet) Template**: Added posts introducing a Miro template for creating cause-and-effect diagrams that map system influences. Includes both English and Portuguese versions with links to the Miroverse template.

- **Modular Software Development**: Added podcast episode posts from Beyond Coding discussing modular design principles, module interfaces, and the relationship between code structure and team organization. Bilingual versions included.

- **Team Topologies & Conway's Law**: Added posts exploring how organizational structure affects software architecture, featuring insights from the Team Topologies framework and practical lessons from engineering management. Both English and Portuguese versions provided.

- **Diversity in Tech**: Added roundtable discussion post from Leap into Tech podcast examining systemic barriers in the tech industry and approaches to building inclusive organizations. Bilingual content included.

## Implementation Details
- All posts follow the existing Jekyll blog structure with proper front matter (lang, layout, date, categories, tags, permalink)
- Portuguese versions include `permalink` field for proper URL routing; English versions rely on default URL generation
- Posts embed multimedia content (YouTube and Spotify iframes) with responsive styling
- Consistent tagging across posts using `midia` tag for media/podcast content
- Posts span multiple categories: `coding` (software design topics) and `people` (organizational/diversity topics)

https://claude.ai/code/session_01Y2G3PQTn4AvaETu4JfMaPt