### PR TITLE
feat: add personal opinions disclaimer to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,7 +16,7 @@
       {% if site.active_lang == 'pt-br' %}Feito com{% else %}Built with{% endif %} <a href="https://jekyllrb.com">Jekyll</a>.
     </p>
     <p class="footer-text footer-disclaimer">
-      {% if site.active_lang == 'pt-br' %}As opiniões expressas aqui são minhas e não refletem as de meu empregador.{% else %}Opinions expressed here are my own and do not reflect those of my employer.{% endif %}
+      {% if site.active_lang == 'pt-br' %}As opiniões expressas aqui são minhas e não refletem necessariamente as de meu empregador.{% else %}Opinions expressed here are my own and do not necessarily reflect those of my employer.{% endif %}
     </p>
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,5 +15,8 @@
       &copy; {{ site.time | date: '%Y' }} {{ site.author.name | default: site.title }}.
       {% if site.active_lang == 'pt-br' %}Feito com{% else %}Built with{% endif %} <a href="https://jekyllrb.com">Jekyll</a>.
     </p>
+    <p class="footer-text footer-disclaimer">
+      {% if site.active_lang == 'pt-br' %}As opiniões expressas aqui são minhas e não refletem as de meu empregador.{% else %}Opinions expressed here are my own and do not reflect those of my employer.{% endif %}
+    </p>
   </div>
 </footer>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -601,6 +601,12 @@ hr {
   margin: 0;
 }
 
+.footer-disclaimer {
+  font-size: 0.75rem;
+  margin-top: 0.35rem;
+  opacity: 0.7;
+}
+
 // Copilot sparkle effect
 .copilot-sparkle {
   position: relative;

--- a/tests/homepage.spec.ts
+++ b/tests/homepage.spec.ts
@@ -43,7 +43,7 @@ test.describe('English homepage', () => {
   });
 
   test('footer shows "Built with Jekyll"', async ({ page }) => {
-    await expect(page.locator('.footer-text')).toContainText('Built with Jekyll');
+    await expect(page.locator('.footer-text').first()).toContainText('Built with Jekyll');
   });
 });
 
@@ -76,6 +76,6 @@ test.describe('PT-BR homepage', () => {
   });
 
   test('footer shows "Feito com Jekyll"', async ({ page }) => {
-    await expect(page.locator('.footer-text')).toContainText('Feito com Jekyll');
+    await expect(page.locator('.footer-text').first()).toContainText('Feito com Jekyll');
   });
 });


### PR DESCRIPTION
Adds a bilingual disclaimer ("Opinions expressed here are my own and do
not reflect those of my employer." / PT-BR equivalent) as a second line
in the site footer. Updates homepage tests to scope the Jekyll credit
check to the first .footer-text element now that there are two.

https://claude.ai/code/session_01HjCLmoRHihVeU7vz3q9xjj