### PR TITLE
feat: add update note about imported old posts to "finally writing again"

### DIFF
--- a/_posts/2026-02-25-finally-writing-again-pt-br.md
+++ b/_posts/2026-02-25-finally-writing-again-pt-br.md
@@ -31,3 +31,7 @@ Como John Udell provocou em seu post: [Too busy to blog? Count your keystrokes](
 Escrever é uma das melhores formas de consolidar o aprendizado. Cada vez que resolvo um problema interessante ou descubro algo novo, quero registrar esse conhecimento e compartilhá-lo - tanto para quem possa enfrentar os mesmos desafios quanto para o meu eu do futuro.
 
 Bem-vindo de volta! A nós dois!
+
+---
+
+**Atualização:** Após publicar este primeiro post neste novo site, decidi importar os meus posts antigos (alguns que já eram públicos, outros que tinham ficado privados) para cá. É por isso que você pode encontrar posts aqui mais antigos do que este.

--- a/_posts/2026-02-25-finally-writing-again.md
+++ b/_posts/2026-02-25-finally-writing-again.md
@@ -30,3 +30,7 @@ As John Udell challenged in his post: [Too busy to blog? Count your keystrokes](
 Writing is one of the best ways to consolidate learning. Every time I solve an interesting problem or discover something new, I want to capture that knowledge and share it, both for others who might run into the same challenges and for my future self.
 
 Welcome back: to both of us!
+
+---
+
+**Update:** After writing this first post on this new website, I decided to import my old posts (some that were already public, others that had stayed private) into this new home. That is why you may find posts here that are older than this one.


### PR DESCRIPTION
Adds an **Update** section at the bottom of both language versions of the post "From events to podcasts - a quiet few years", explaining that older posts were imported after this first one was published.

## Preview

The section appears after a horizontal rule at the end of each post:

---

**English** (`2026-02-25-finally-writing-again.md`):

> ---
>
> **Update:** After writing this first post on this new website, I decided to import my old posts (some that were already public, others that had stayed private) into this new home. That is why you may find posts here that are older than this one.

---

**Portuguese** (`2026-02-25-finally-writing-again-pt-br.md`):

> ---
>
> **Atualização:** Após publicar este primeiro post neste novo site, decidi importar os meus posts antigos (alguns que já eram públicos, outros que tinham ficado privados) para cá. É por isso que você pode encontrar posts aqui mais antigos do que este.

---

> **Note:** Jekyll was not available in the local environment, so `npm test` could not be run. The CI pipeline will validate the build and tests on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUwjhSwxjxTAFSYV7owrLt)_