### PR TITLE
fix: remove .github/ prefix from home page code section filename

### DIFF
--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ lang: en
         <span class="dot yellow"></span>
         <span class="dot green"></span>
       </div>
-      <span class="filename">.github/andre-borgonovo.agent.md</span>
+      <span class="filename">andre-borgonovo.agent.md</span>
     </div>
     <div class="code-content">
 <pre class="agent-code"><span class="cw-sep">---</span>

--- a/pt-br/index.md
+++ b/pt-br/index.md
@@ -13,7 +13,7 @@ permalink: /
         <span class="dot yellow"></span>
         <span class="dot green"></span>
       </div>
-      <span class="filename">.github/andre-borgonovo.agent.md</span>
+      <span class="filename">andre-borgonovo.agent.md</span>
     </div>
     <div class="code-content">
 <pre class="agent-code"><span class="cw-sep">---</span>


### PR DESCRIPTION
https://claude.ai/code/session_01KdB8P5UXt6RGsSkWyuv7cz