### PR TITLE
docs: add conditional test execution guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,9 +4,26 @@ For the full project reference — structure, bilingual Jekyll/polyglot conventi
 
 ## Key Rules
 
-- **Run tests after changes**: `npm test` must pass before any task is complete. If tests fail, diagnose and fix.
+- **Run tests after changes**: `npm test` must pass when changes affect verifiable functionality (see [When to run tests](#when-to-run-tests) below). If tests fail, diagnose and fix.
 - **Scope**: Only make changes directly requested. Do not refactor surrounding code or add features beyond what was asked.
 - **Bilingual posts**: Every post requires a `lang: en` and `lang: pt-br` pair, both in `_posts/`.
 - **Liquid syntax**: Wrap `{{ }}` / `{% %}` patterns in `{% raw %}…{% endraw %}`; add a test case in `tests/liquid-expressions.spec.ts`.
 - **Branching**: Work on a feature branch; never commit directly to `main`.
 - **Commits**: Follow Conventional Commits (`feat:`, `fix:`, `docs:`, `style:`, `test:`, `chore:`); subject ≤ 72 characters.
+
+## When to run tests
+
+**Run `npm test`** when changes affect:
+- `_layouts/` — layout files control what tests validate
+- `_includes/` — include files affect navigation, header, footer
+- `assets/css/` — style changes can break layout assumptions
+- `_config.yml` — site configuration affects routing and language handling
+- `_posts/` — **only** if: (1) changing Liquid-syntax code blocks (wrap in `{% raw %}`); (2) adding/updating post front matter that affects categories/tags/language filtering; or (3) modifying anything beyond post body text
+- `tests/` — test file changes must pass
+
+**Do NOT run tests** when changes are only:
+- Documentation files (`README.md`, `CONTRIBUTING.md`, instruction files)
+- Post body text (prose/content without layout/front-matter changes)
+- Image assets or static files (`assets/images/`, `assets/files/`)
+- Comments or metadata in code
+- CI/CD workflow files (`.github/workflows/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,27 @@ bundle exec jekyll serve
 npm test
 ```
 
-After making changes, validate by running `npm test` and checking that all Playwright tests pass.
+### Test strategy
+
+Tests should run only when changes can affect tested functionality. Avoid running Playwright for documentation updates or pure content changes.
+
+**What tests validate:**
+- `homepage.spec.ts` — homepage layout, nav structure, hero section, social links, footer (affected by layout/include/style changes)
+- `navigation.spec.ts` — language toggle, nav links, routing (affected by header changes)
+- `posts.spec.ts` — post list filtering, language isolation (affected by post layout or language filtering logic)
+- `liquid-expressions.spec.ts` — Liquid code blocks render literally in posts (affected only by specific posts with `{% raw %}` blocks)
+
+**When to run tests:**
+- Changes to `_layouts/`, `_includes/`, or `assets/css/`
+- Changes to `_config.yml` affecting routing or language handling
+- Posts with Liquid-syntax expressions or front-matter changes affecting filtering
+- Changes to test files
+
+**When to skip tests:**
+- Documentation or instruction files (*.md in root, except `_posts/`)
+- Post body text (prose only)
+- Image/static asset changes
+- CI/CD workflow changes
 
 ### Test naming convention
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,24 @@
 
 ## Claude-Specific Rules
 
-### Always run tests before finishing
+### Run tests conditionally
 
-Run `npm test` after any change to layouts, includes, styles, posts, or configuration. If tests fail, diagnose and fix — do not consider the task done with failing tests.
+Run `npm test` **only when changes affect functionality that tests verify**.
+
+**ALWAYS run tests** when changing:
+- `_layouts/*` or `_includes/*` — layouts/includes directly control tested HTML
+- `assets/css/*` — styles affect layout validation
+- `_config.yml` — site configuration affects routing/language
+- Test files (`tests/*`)
+- Posts with Liquid-syntax expressions that must render literally
+
+**SKIP tests** for:
+- Instruction files (`CLAUDE.md`, `AGENTS.md`, copilot-instructions.md)
+- Documentation (`README.md`, `CONTRIBUTING.md`)
+- Post body text (prose only, not front matter)
+- Static assets, comments, metadata
+
+If tests fail after changes that *should* run them, diagnose and fix — do not skip the failure.
 
 ### Scope
 
@@ -14,4 +29,4 @@ Only make changes directly requested. Do not refactor surrounding code, add unre
 
 ### Liquid syntax in post content
 
-When adding a post with Liquid-syntax code examples (wrapped in `{% raw %}…{% endraw %}`), add a corresponding test case in `tests/liquid-expressions.spec.ts` to guard against regressions.
+When adding a post with Liquid-syntax code examples (wrapped in `{% raw %}…{% endraw %}`), add a corresponding test case in `tests/liquid-expressions.spec.ts` to guard against regressions. Tests must run to validate the Liquid wrapping.


### PR DESCRIPTION
- Run tests only when changes affect verifiable functionality
- Skip tests for documentation, post body text, and static assets
- Add 'When to run tests' and 'When to skip tests' sections
- Clarify which test files validate which features
- Update CLAUDE.md and .github/copilot-instructions.md accordingly